### PR TITLE
Move development dependencies from travis file to requirements file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
 install:
 - pip install .
 - pip install -r requirements.txt
-- pip install pytest
-- pip install coverage
-- pip install pytest-cov
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-urllib3
-requests
-uplink==0.7.0
-pandas
-IPython
 sphinx
 sphinx_rtd_theme
 nbsphinx
 pandoc
+pytest
+coverage
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@ sphinx
 sphinx_rtd_theme
 nbsphinx
 pandoc
-pytest
-coverage
 pytest-cov


### PR DESCRIPTION
reasoning: single source of dependency truth